### PR TITLE
The name of the app is World In.

### DIFF
--- a/example.es6
+++ b/example.es6
@@ -1,5 +1,8 @@
 import React from 'react';
-import WINHTML from './index.es6';
+
+// TODO: Without a postfix of /index.es6 there is a crash.
+import HtmlDocument from './index.es6';
+
 export default (
-  <WINHTML path="/404/" />
+  <HtmlDocument path="/404/" />
 );

--- a/index.css
+++ b/index.css
@@ -1,4 +1,5 @@
 body {
   margin: 0;
 }
+
 @import '@economist/component-win-app';

--- a/index.es6
+++ b/index.es6
@@ -1,9 +1,13 @@
 import React from 'react';
-import TQApp from '@economist/component-win-app';
+
+// TODO: Without a postfix of /index.es6 there is a crash.
+import WinApp from '@economist/component-win-app/index.es6';
+
 import ArticleStore from '@economist/component-articlestore';
 
 const articleStore = new ArticleStore('/content');
-export default class WINHTML extends React.Component {
+
+export default class HtmlDocument extends React.Component {
 
   static get propTypes() {
     return {
@@ -90,7 +94,7 @@ export default class WINHTML extends React.Component {
           {this.renderInlineScripts()}
         </head>
         <body data-id={this.pageDataID()} >
-          <TQApp path={this.props.path} />
+          <WinApp path={this.props.path} />
         </body>
       </html>
     );

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@economist/component-win-html",
   "version": "1.0.0",
-  "description": "The World in HTML wrapper",
+  "description": "The World In HTML wrapper",
   "author": "The Economist (http://economist.com)",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
# The changes
- [x] The name of the app is World In.
- [x] The `Store` component has been removed.

# Note

## Refactor

I think I might alter this so that it just exports an `HtmlDocument` which can wrap *any* `App` component. This will be done in a separate PR. I will keep the general name for now, but eventually we would be able to create a `component-html` that is not world-in specific.

## Fatal errors

I have noticed that there are two fatal issues with the project.

1. If I try to commit a pre-commit hook runs eslint which fails within the module `estraverse` with a cannot read length of undefined. Gross.

2. I notice within the code that the import statements to our modules are not working unless I write `’./index.es6’` instead of `’.’`, etc. On running `npm run serve` and shortening the imports I get a `throw new Error('No element indexed by ' + aIdx);` from deep within `combine-source-map` -> `source-map`. While developing I do have an `npm link` between the two packages but it probably isn’t this - something `component-devserver` does when setting up sourcemaps is probably wrong.

I am going to create a separate PR after this is merged to try to fix these by switching to the new `component-devpack`.